### PR TITLE
Automatically select last used app feature

### DIFF
--- a/src/appfinder-model.c
+++ b/src/appfinder-model.c
@@ -35,6 +35,8 @@
 
 #define HISTORY_PATH   "xfce4/xfce4-appfinder/history"
 #define BOOKMARKS_PATH "xfce4/appfinder/bookmarks"
+#define FREQUENCY_PATH "xfce4/appfinder/frequency"
+#define RECENCY_PATH   "xfce4/appfinder/recency"
 
 
 static void               xfce_appfinder_model_tree_model_init        (GtkTreeModelIface        *iface);
@@ -102,7 +104,10 @@ static void               xfce_appfinder_model_bookmarks_monitor      (XfceAppfi
 
 static gboolean           xfce_appfinder_model_fuzzy_match            (const gchar              *source,
                                                                        const gchar              *token);
-
+static void               xfce_appfinder_model_frequency_collect      (XfceAppfinderModel       *model,
+                                                                       GMappedFile              *mmap);
+static void               xfce_appfinder_model_recency_collect        (XfceAppfinderModel       *model,
+                                                                       GMappedFile              *mmap);
 
 struct _XfceAppfinderModelClass
 {
@@ -119,6 +124,8 @@ struct _XfceAppfinderModel
   GHashTable            *items_hash;
 
   GHashTable            *bookmarks_hash;
+  GHashTable            *frequencies_hash;
+  GHashTable            *recencies_hash;
 
   GFileMonitor          *bookmarks_monitor;
   GFile                 *bookmarks_file;
@@ -157,6 +164,9 @@ typedef struct
   gchar          *tooltip;
   guint           not_visible : 1;
   guint           is_bookmark : 1;
+
+  guint           frequency;
+  guint64         recency;
 
   GdkPixbuf      *icon;
   GdkPixbuf      *icon_large;
@@ -230,6 +240,8 @@ xfce_appfinder_model_init (XfceAppfinderModel *model)
   model->stamp = g_random_int ();
   model->items_hash = g_hash_table_new (g_str_hash, g_str_equal);
   model->bookmarks_hash = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
+  model->frequencies_hash = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
+  model->recencies_hash = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
   model->icon_size = XFCE_APPFINDER_ICON_SIZE_DEFAULT_ITEM;
   model->command_icon = xfce_appfinder_model_load_pixbuf (XFCE_APPFINDER_STOCK_EXECUTE, model->icon_size);
   model->command_icon_large = xfce_appfinder_model_load_pixbuf (XFCE_APPFINDER_STOCK_EXECUTE, XFCE_APPFINDER_ICON_SIZE_48);
@@ -362,6 +374,8 @@ xfce_appfinder_model_finalize (GObject *object)
 
   g_hash_table_destroy (model->items_hash);
   g_hash_table_destroy (model->bookmarks_hash);
+  g_hash_table_destroy (model->frequencies_hash);
+  g_hash_table_destroy (model->recencies_hash);
 
   g_object_unref (G_OBJECT (model->command_icon_large));
   g_object_unref (G_OBJECT (model->command_icon));
@@ -410,6 +424,12 @@ xfce_appfinder_model_get_column_type (GtkTreeModel *tree_model,
     case XFCE_APPFINDER_MODEL_COLUMN_BOOKMARK:
       return G_TYPE_BOOLEAN;
 
+    case XFCE_APPFINDER_MODEL_COLUMN_FREQUENCY:
+      return G_TYPE_UINT;
+
+    case XFCE_APPFINDER_MODEL_COLUMN_RECENCY:
+      return G_TYPE_UINT64;
+      
     default:
       g_assert_not_reached ();
       return G_TYPE_INVALID;
@@ -598,6 +618,16 @@ xfce_appfinder_model_get_value (GtkTreeModel *tree_model,
       g_value_set_boolean (value, item->is_bookmark);
       break;
 
+    case XFCE_APPFINDER_MODEL_COLUMN_FREQUENCY:
+      g_value_init (value, G_TYPE_UINT);
+      g_value_set_uint (value, item->frequency);
+      break;
+
+    case XFCE_APPFINDER_MODEL_COLUMN_RECENCY:
+      g_value_init (value, G_TYPE_UINT64);
+      g_value_set_uint64 (value, item->recency);
+      break;
+      
     default:
       g_assert_not_reached ();
       break;
@@ -732,6 +762,8 @@ xfce_appfinder_model_collect_idle (gpointer user_data)
   GSList             *tmp;
   ModelItem          *item;
   const gchar        *desktop_id;
+  guint               item_frequency;
+  gpointer           *item_recency_ptr;
 
   appfinder_return_val_if_fail (XFCE_IS_APPFINDER_MODEL (model), FALSE);
   appfinder_return_val_if_fail (model->items == NULL, FALSE);
@@ -771,6 +803,18 @@ xfce_appfinder_model_collect_idle (gpointer user_data)
 
           desktop_id = garcon_menu_item_get_desktop_id (item->item);
           item->is_bookmark = g_hash_table_lookup (model->bookmarks_hash, desktop_id) != NULL;
+          item_frequency = GPOINTER_TO_UINT(g_hash_table_lookup (model->frequencies_hash, desktop_id));
+          item_recency_ptr = g_hash_table_lookup (model->recencies_hash, desktop_id);
+          
+          if (item_frequency)
+            item->frequency = item_frequency;
+          else
+            item->frequency = 0;
+          
+          if (item_recency_ptr)
+            item->recency = *((guint64 *)item_recency_ptr);
+          else
+            item->recency = 0;
         }
 
       /* insert in hash table */
@@ -916,6 +960,8 @@ xfce_appfinder_model_item_changed (GarconMenuItem     *menu_item,
   GPtrArray   *categories;
   gboolean     old_not_visible;
   const gchar *desktop_id;
+  guint        item_frequency;
+  gpointer    *item_recency;
 
   /* lookup the item in the list */
   for (li = model->items, idx = 0; li != NULL; li = li->next, idx++)
@@ -939,9 +985,26 @@ xfce_appfinder_model_item_changed (GarconMenuItem     *menu_item,
           /* check if the item should be a bookmark */
           desktop_id = garcon_menu_item_get_desktop_id (menu_item);
           if (desktop_id != NULL)
-            item->is_bookmark = g_hash_table_lookup (model->bookmarks_hash, desktop_id) != NULL;
+            {
+              item->is_bookmark = g_hash_table_lookup (model->bookmarks_hash, desktop_id) != NULL;
+              item_frequency = GPOINTER_TO_UINT(g_hash_table_lookup (model->frequencies_hash, desktop_id));
+              item_recency =  g_hash_table_lookup (model->recencies_hash, desktop_id);
+              if (item_frequency)
+                item->frequency = item_frequency;
+              else
+                item->frequency = 0;
+                
+              if (item_recency)
+                item->recency = *((guint64 *)item_recency);
+              else
+                item->recency = 0;
+            }
           else
-            item->is_bookmark = FALSE;
+            {
+              item->is_bookmark = FALSE;
+              item->frequency = 0;
+              item->recency = 0;
+            }
 
           if (G_LIKELY (item->command != NULL))
             g_hash_table_insert (model->items_hash, item->command, item);
@@ -1891,6 +1954,48 @@ xfce_appfinder_model_collect_thread (gpointer user_data)
 
       g_free (filename);
     }
+  
+  /* load frequencies */
+  filename = xfce_resource_lookup (XFCE_RESOURCE_CONFIG, FREQUENCY_PATH);
+  if (G_LIKELY (filename != NULL))
+    {
+      APPFINDER_DEBUG ("load frequency from %s", filename);
+
+      mmap = g_mapped_file_new (filename, FALSE, &error);
+      if (G_LIKELY (mmap != NULL))
+        {
+          xfce_appfinder_model_frequency_collect (model, mmap);
+          g_mapped_file_unref (mmap);
+        }
+      else
+        {
+          g_warning ("Failed to open frequency file: %s", error->message);
+          g_clear_error (&error);
+        }
+
+      g_free (filename);
+    }
+    
+    /* load recencies */
+  filename = xfce_resource_lookup (XFCE_RESOURCE_CONFIG, RECENCY_PATH);
+  if (G_LIKELY (filename != NULL))
+    {
+      APPFINDER_DEBUG ("load recency from %s", filename);
+
+      mmap = g_mapped_file_new (filename, FALSE, &error);
+      if (G_LIKELY (mmap != NULL))
+        {
+          xfce_appfinder_model_recency_collect (model, mmap);
+          g_mapped_file_unref (mmap);
+        }
+      else
+        {
+          g_warning ("Failed to open recency file: %s", error->message);
+          g_clear_error (&error);
+        }
+
+      g_free (filename);
+    }
 
   if (model->collect_items != NULL
       && !g_cancellable_is_cancelled (model->collect_cancelled))
@@ -1911,6 +2016,186 @@ xfce_appfinder_model_collect_thread (gpointer user_data)
   APPFINDER_DEBUG ("collect thread end");
 
   return NULL;
+}
+
+
+
+static void
+xfce_appfinder_model_frequency_collect (XfceAppfinderModel  *model,
+                                        GMappedFile         *mmap)
+{
+  gchar       *line;
+  gchar      **line_contents;
+  gchar       *end;
+  gchar       *contents;
+  guint        frequency;
+
+  contents = g_mapped_file_get_contents (mmap);
+  if (contents == NULL)
+    return;
+    
+  /* walk the file */
+  for (; !g_cancellable_is_cancelled (model->collect_cancelled);)
+    {
+      end = strchr (contents, '\n');
+      if (G_UNLIKELY (end == NULL))
+        break;
+
+      if (end != contents)
+        {
+          line = g_strndup (contents, end - contents);
+          line_contents = g_strsplit (line, ":", 2);
+          if (line_contents[0] != NULL && line_contents[1] != NULL)
+            {
+              frequency = g_ascii_strtoull (line_contents[1], NULL, 0);
+              g_hash_table_insert (model->frequencies_hash, line_contents[0], GUINT_TO_POINTER (frequency));
+            }
+          
+          g_free (line);
+        }
+        
+      contents = end + 1;
+    }
+    
+}
+
+
+static void
+xfce_appfinder_model_recency_collect   (XfceAppfinderModel  *model,
+                                        GMappedFile         *mmap)
+{
+  gchar       *line;
+  gchar      **line_contents;
+  gchar       *end;
+  gchar       *contents;
+  guint64      recency;
+  guint64     *recency_ptr;
+  
+  contents = g_mapped_file_get_contents (mmap);
+  if (contents == NULL)
+    return;
+    
+  /* walk the file */
+  for (; !g_cancellable_is_cancelled (model->collect_cancelled);)
+    {
+      end = strchr (contents, '\n');
+      if (G_UNLIKELY (end == NULL))
+        break;
+
+      if (end != contents)
+        {
+          line = g_strndup (contents, end - contents);
+          line_contents = g_strsplit (line, ":", 2);
+          if (line_contents[0] != NULL && line_contents[1] != NULL)
+            {
+              recency_ptr = g_new0 (guint64 , 1);
+              recency = g_ascii_strtoull (line_contents[1], NULL, 0);
+              *recency_ptr = recency;
+              g_hash_table_insert (model->recencies_hash, line_contents[0], recency_ptr);
+            }
+          
+          g_free (line);
+        }
+        
+      contents = end + 1;
+    }
+}
+
+
+
+void
+xfce_appfinder_model_update_frecency (XfceAppfinderModel *model,
+                                       const gchar        *desktop_id,
+                                       GError            **error)
+{
+  ModelItem    *item;
+  GSList       *li;
+  const gchar  *desktop_id2;
+  GString      *frequency_contents;
+  GString      *recency_contents;
+  gchar        *filename;
+  GtkTreePath  *path;
+  gint          idx;
+  GtkTreeIter   iter;
+  GDateTime    *now;
+
+  appfinder_return_if_fail (XFCE_IS_APPFINDER_MODEL (model));
+  appfinder_return_if_fail (error == NULL || *error == NULL);
+  appfinder_return_if_fail (desktop_id != NULL);
+
+  frequency_contents = g_string_sized_new (0);
+  recency_contents = g_string_sized_new (0);
+
+  /* update the model items */
+  for (idx = 0, li = model->items; li != NULL; li = li->next, idx++)
+    {
+      item = li->data;
+      if (item->item == NULL)
+        continue;
+
+      desktop_id2 = garcon_menu_item_get_desktop_id (item->item);
+      /* find the item we're trying to add/remove */
+      if (desktop_id != NULL)
+        {
+          if (desktop_id2 != NULL
+              && strcmp (desktop_id2, desktop_id) == 0)
+            {
+              /* update frequency */
+              item->frequency = item->frequency + 1;
+              
+              /*update recency */
+              now = g_date_time_new_now_local ();
+              item->recency = g_date_time_to_unix (now);
+              g_date_time_unref (now);
+
+              /* stop searching, continue collecting */
+              desktop_id = NULL;
+
+              /* update model */
+              path = gtk_tree_path_new_from_indices (idx, -1);
+              ITER_INIT (iter, model->stamp, li);
+              gtk_tree_model_row_changed (GTK_TREE_MODEL (model), path, &iter);
+              gtk_tree_path_free (path);
+            }
+        }
+
+      /* collect items' frecency */
+      if (desktop_id2 != NULL)
+        {
+          g_string_append (frequency_contents, g_strdup_printf ("%s:%" G_GUINT32_FORMAT, desktop_id2, item->frequency));
+          g_string_append_c (frequency_contents, '\n');
+          
+          g_string_append (recency_contents, g_strdup_printf ("%s:%" G_GUINT64_FORMAT, desktop_id2, item->recency));
+          g_string_append_c (recency_contents, '\n');
+        }
+    }
+
+  APPFINDER_DEBUG ("saving frecencies");
+
+  /* write new frecencies */
+  filename = xfce_resource_save_location (XFCE_RESOURCE_CONFIG, FREQUENCY_PATH, TRUE);
+  if (G_LIKELY (filename != NULL))
+    {
+      g_file_set_contents (filename, frequency_contents->str, frequency_contents->len, NULL);
+    }
+  else
+    {
+      g_set_error_literal (error, 0, 0, "Unable to create frequency file");
+    }
+  
+  filename = xfce_resource_save_location (XFCE_RESOURCE_CONFIG, RECENCY_PATH, TRUE);
+  if (G_LIKELY (filename != NULL))
+    {
+      g_file_set_contents (filename, recency_contents->str, recency_contents->len, NULL);
+    }
+  else
+    {
+      g_set_error_literal (error, 0, 0, "Unable to create recency file");
+    }
+
+  g_free (filename);
+  g_string_free (frequency_contents, TRUE);
+  g_string_free (recency_contents, TRUE);
 }
 
 

--- a/src/appfinder-model.h
+++ b/src/appfinder-model.h
@@ -43,6 +43,8 @@ enum
   XFCE_APPFINDER_MODEL_COLUMN_COMMAND,
   XFCE_APPFINDER_MODEL_COLUMN_URI,
   XFCE_APPFINDER_MODEL_COLUMN_BOOKMARK,
+  XFCE_APPFINDER_MODEL_COLUMN_FREQUENCY,
+  XFCE_APPFINDER_MODEL_COLUMN_RECENCY,
   XFCE_APPFINDER_MODEL_COLUMN_TOOLTIP,
   XFCE_APPFINDER_MODEL_N_COLUMNS,
 };
@@ -108,6 +110,9 @@ gboolean             xfce_appfinder_model_bookmark_toggle        (XfceAppfinderM
 GarconMenuDirectory *xfce_appfinder_model_get_command_category   (void);
 
 GarconMenuDirectory *xfce_appfinder_model_get_bookmarks_category (void);
+void                 xfce_appfinder_model_update_frecency        (XfceAppfinderModel       *model,
+                                                                  const gchar              *desktop_id,
+                                                                  GError                  **error);
 
 G_END_DECLS
 

--- a/src/appfinder-model.h
+++ b/src/appfinder-model.h
@@ -69,7 +69,7 @@ XfceAppfinderIconSize;
 
 GType                xfce_appfinder_model_get_type               (void) G_GNUC_CONST;
 
-XfceAppfinderModel  *xfce_appfinder_model_get                    (void) G_GNUC_MALLOC;
+XfceAppfinderModel  *xfce_appfinder_model_get                    (gboolean                   frecency_order_flag) G_GNUC_MALLOC;
 
 GSList              *xfce_appfinder_model_get_categories         (XfceAppfinderModel        *model);
 
@@ -113,6 +113,8 @@ GarconMenuDirectory *xfce_appfinder_model_get_bookmarks_category (void);
 void                 xfce_appfinder_model_update_frecency        (XfceAppfinderModel       *model,
                                                                   const gchar              *desktop_id,
                                                                   GError                  **error);
+guint                xfce_appfinder_model_calculate_frecency     (guint                     frequency,
+                                                                  guint64                   recency);
 
 G_END_DECLS
 

--- a/src/appfinder-preferences.c
+++ b/src/appfinder-preferences.c
@@ -134,6 +134,10 @@ xfce_appfinder_preferences_init (XfceAppfinderPreferences *preferences)
       G_CALLBACK (xfce_appfinder_preferences_single_window_sensitive), object);
   xfce_appfinder_preferences_single_window_sensitive (GTK_WIDGET (previous), GTK_WIDGET (object));
 
+  object = gtk_builder_get_object (GTK_BUILDER (preferences), "recent-order");
+  xfconf_g_property_bind (preferences->channel, "/recent-order", G_TYPE_BOOLEAN,
+                          G_OBJECT (object), "active");
+
   previous = gtk_builder_get_object (GTK_BUILDER (preferences), "icon-view");
   xfconf_g_property_bind (preferences->channel, "/icon-view", G_TYPE_BOOLEAN,
                           G_OBJECT (previous), "active");

--- a/src/appfinder-preferences.c
+++ b/src/appfinder-preferences.c
@@ -263,7 +263,7 @@ xfce_appfinder_preferences_clear_history (XfceAppfinderPreferences *preferences)
                            _("This will permanently clear the custom command history."),
                            _("Are you sure you want to clear the command history?")))
     {
-      model = xfce_appfinder_model_get ();
+      model = xfce_appfinder_model_get (xfconf_channel_get_bool (preferences->channel, "/recent-order", FALSE));
       xfce_appfinder_model_history_clear (model);
       g_object_unref (G_OBJECT (model));
     }

--- a/src/appfinder-preferences.glade
+++ b/src/appfinder-preferences.glade
@@ -224,6 +224,23 @@
                                 <property name="position">3</property>
                               </packing>
                             </child>
+                            <child>
+                              <object class="GtkCheckButton" id="recent-order">
+                                <property name="label" translatable="yes"> Automatically select recently used item</property>
+                                <property name="use_action_appearance">False</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">False</property>
+                                <property name="tooltip_text" translatable="yes">Order items, such that items that are most recently used are always on the top.</property>
+                                <property name="use_underline">True</property>
+                                <property name="draw_indicator">True</property>
+                              </object>
+                              <packing>
+                                <property name="expand">True</property>
+                                <property name="fill">True</property>
+                                <property name="position">4</property>
+                              </packing>
+                            </child>
                           </object>
                         </child>
                       </object>

--- a/src/appfinder-window.c
+++ b/src/appfinder-window.c
@@ -117,6 +117,13 @@ static gint       xfce_appfinder_window_sort_items                    (GtkTreeMo
                                                                        GtkTreeIter                 *b,
                                                                        gpointer                     data);
 static gboolean   xfce_appfinder_should_sort_icon_view                (void);
+static void       xfce_appfinder_window_update_frecency               (XfceAppfinderWindow         *window,
+                                                                       GtkTreeModel                *model,
+                                                                       const gchar                 *uri);
+static gint       xfce_appfinder_window_sort_items_frecency           (GtkTreeModel                *model,
+                                                                       GtkTreeIter                 *a,
+                                                                       GtkTreeIter                 *b,
+                                                                       gpointer                     data);
 
 struct _XfceAppfinderWindowClass
 {
@@ -702,7 +709,10 @@ xfce_appfinder_window_view (XfceAppfinderWindow *window)
   gtk_tree_model_filter_set_visible_func (GTK_TREE_MODEL_FILTER (window->filter_model), xfce_appfinder_window_item_visible, window, NULL);
 
   window->sort_model = gtk_tree_model_sort_new_with_model (GTK_TREE_MODEL (window->filter_model));
-  gtk_tree_sortable_set_default_sort_func (GTK_TREE_SORTABLE (window->sort_model), xfce_appfinder_window_sort_items, window->entry, NULL);
+  if (xfconf_channel_get_bool (window->channel, "/recent-order", FALSE))
+    gtk_tree_sortable_set_default_sort_func (GTK_TREE_SORTABLE (window->sort_model), xfce_appfinder_window_sort_items_frecency, window->entry, NULL);
+  else
+    gtk_tree_sortable_set_default_sort_func (GTK_TREE_SORTABLE (window->sort_model), xfce_appfinder_window_sort_items, window->entry, NULL);
 
   if (icon_view)
     {
@@ -1817,6 +1827,7 @@ xfce_appfinder_window_execute (XfceAppfinderWindow *window,
   gboolean      regular_command = FALSE;
   gboolean      save_cmd;
   gboolean      only_custom_cmd = FALSE;
+  const gchar  *uri;
 
   screen = gtk_window_get_screen (GTK_WINDOW (window));
   if (gtk_widget_get_visible (window->paned))
@@ -1830,6 +1841,9 @@ xfce_appfinder_window_execute (XfceAppfinderWindow *window,
       if (xfce_appfinder_window_view_get_selected (window, &model, &iter))
         {
           child_model = model;
+          gtk_tree_model_get (model, &iter,
+                              XFCE_APPFINDER_MODEL_COLUMN_URI, &uri,
+                              -1);
 
           if (GTK_IS_TREE_MODEL_SORT (model) || xfce_appfinder_should_sort_icon_view ())
             {
@@ -1841,6 +1855,7 @@ xfce_appfinder_window_execute (XfceAppfinderWindow *window,
           gtk_tree_model_filter_convert_iter_to_child_iter (GTK_TREE_MODEL_FILTER (child_model), &child_iter, &iter);
           result = xfce_appfinder_model_execute (window->model, &child_iter, screen, &regular_command, &error);
 
+          xfce_appfinder_window_update_frecency (window, model, uri);
           if (!result && regular_command)
             {
               gtk_tree_model_get (model, &child_iter, XFCE_APPFINDER_MODEL_COLUMN_COMMAND, &cmd, -1);
@@ -1884,6 +1899,32 @@ xfce_appfinder_window_execute (XfceAppfinderWindow *window,
 
   if (result && close_on_succeed)
     gtk_widget_destroy (GTK_WIDGET (window));
+}
+
+
+
+static void
+xfce_appfinder_window_update_frecency (XfceAppfinderWindow *window,
+                                        GtkTreeModel        *model,
+                                        const gchar         *uri)
+{
+  GFile      *gfile;
+  gchar      *desktop_id;
+  GError     *error = NULL;
+
+  if (uri != NULL)
+    {
+      gfile = g_file_new_for_uri (uri);
+      desktop_id = g_file_get_basename (gfile);
+      g_object_unref (G_OBJECT (gfile));
+      APPFINDER_DEBUG ("desktop : %s", desktop_id);
+
+      model = gtk_tree_model_filter_get_model (GTK_TREE_MODEL_FILTER (window->filter_model));
+      xfce_appfinder_model_update_frecency (XFCE_APPFINDER_MODEL (model), desktop_id, &error);
+
+      g_free (desktop_id);
+      g_free (error);
+    }
 }
 
 
@@ -1984,6 +2025,64 @@ xfce_appfinder_window_sort_items (GtkTreeModel *model,
   g_free (title_a);
   g_free (title_b);
   return result;
+}
+
+
+
+static gint
+xfce_appfinder_window_sort_items_frecency  (GtkTreeModel *model,
+                                            GtkTreeIter  *a,
+                                            GtkTreeIter  *b,
+                                            gpointer      data)
+{
+  gint        a_freq, b_freq;
+  gint64      a_rec, b_rec;
+  gint        a_res, b_res;
+  GDateTime  *date_time_now;
+  guint64     unix_time_now;
+  guint64     diff;
+  
+  date_time_now = g_date_time_new_now_local ();
+  unix_time_now = g_date_time_to_unix (date_time_now);
+  g_date_time_unref (date_time_now);
+
+  gtk_tree_model_get (model, a,
+                      XFCE_APPFINDER_MODEL_COLUMN_FREQUENCY, &a_freq,
+                      -1);
+  gtk_tree_model_get (model, b,
+                      XFCE_APPFINDER_MODEL_COLUMN_FREQUENCY, &b_freq,
+                      -1);
+                      
+  gtk_tree_model_get (model, a,
+                      XFCE_APPFINDER_MODEL_COLUMN_RECENCY, &a_rec,
+                      -1);
+  gtk_tree_model_get (model, b,
+                      XFCE_APPFINDER_MODEL_COLUMN_RECENCY, &b_rec,
+                      -1);
+
+  diff = unix_time_now - a_rec;
+
+  if (diff < 3600)
+    a_res = a_freq * 4;
+  else if (diff < 86400)
+    a_res = a_freq * 2;
+  else if (diff < 604800)
+    a_res = a_freq / 2;
+  else
+    a_res = a_freq / 4;
+  
+  diff = unix_time_now - b_rec;
+
+  if (diff < 3600)
+    b_res = b_freq * 4;
+  else if (diff < 86400)
+    b_res = b_freq * 2;
+  else if (diff < 604800)
+    b_res = b_freq / 2;
+  else
+    b_res = b_freq / 4;
+
+  return b_res - a_res;
 }
 
 

--- a/src/appfinder-window.c
+++ b/src/appfinder-window.c
@@ -2082,7 +2082,10 @@ xfce_appfinder_window_sort_items_frecency  (GtkTreeModel *model,
   else
     b_res = b_freq / 4;
 
-  return b_res - a_res;
+  if (b_res - a_res != 0)
+    return b_res - a_res;
+  else
+    return xfce_appfinder_window_sort_items (model, a, b, data);
 }
 
 

--- a/src/main.c
+++ b/src/main.c
@@ -145,7 +145,8 @@ appfinder_window_destroyed (GtkWidget *window)
   if (model_cache == NULL)
     {
       APPFINDER_DEBUG ("main took reference on the main model");
-      model_cache = xfce_appfinder_model_get ();
+      channel = xfconf_channel_get ("xfce4-appfinder");
+      model_cache = xfce_appfinder_model_get (xfconf_channel_get_bool (channel, "/recent-order", FALSE));
     }
 
   /* remove from internal list */


### PR DESCRIPTION
Hi Andre,
This is a feature implementation that fixes Bug 9265, it's an implementation of the Frecency Algorithm, by keeping track of the item's frequency, and recency, the Frecency is then calculated using these two members according to the algorithm described [here](https://github.com/rupa/z/wiki/frecency).

I've also included it as an option for the user whether to sort items according to the most recent/used order, otherwise it's set by default to be based on the alphabetical order.

I'll be waiting for your review and comments, thanks